### PR TITLE
Support customizing the certificate install folder

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 certificates: []
+certificates_directory: /tmp

--- a/tasks/install_cert.yml
+++ b/tasks/install_cert.yml
@@ -1,0 +1,13 @@
+- name: Copy {{ cert }} to {{ certificates_directory }}
+  copy:
+    src: "{{ cert }}"
+    dest: "{{ certificates_directory }}/{{ cert }}"
+    owner: root
+    group: wheel
+    mode: 0644
+  register: file
+
+- name: Install and trust the certificate
+  shell: /usr/bin/security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain {{ certificates_directory }}/{{ cert }}
+  become: true
+  when: file.changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 
-- name: Copy certificate to /tmp
-  copy:
-    src: "{{ item }}"
-    dest: /tmp/{{ item }}
-  loop: "{{ certificates }}"
+- name: Make sure {{ certificates_directory }} exists
+  file:
+    path: "{{ certificates_directory }}"
+    owner: root
+    group: wheel
+    mode: 0755
+    state: directory
 
-- name: Install and trust the certificate
-  shell: /usr/bin/security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /tmp/{{ item }}
-  become: true
+- include: install_cert.yml cert="{{ item }}"
   loop: "{{ certificates }}"


### PR DESCRIPTION
This changes as a variable named `certificates_directory` so you can customize where the cert gets copied to. This allows us to skip re-importing the cert if it's already copied into place. Ideally we'd use the security command to tell if the cert is installed or not but I think it's more trouble than it's worth right now.